### PR TITLE
feat: centralize all static UI text into i18n translation file

### DIFF
--- a/src/app/about-us/page.tsx
+++ b/src/app/about-us/page.tsx
@@ -5,6 +5,7 @@ import { MissionCard } from "@/components/ui/cards/MissionCard";
 import { useAOS } from "@/hooks/useAOS";
 import { useState, useEffect, useMemo } from "react";
 import { useLanguage } from "@/contexts/LanguageContext";
+import { useTranslation } from "@/i18n";
 import {
     fetchRawAboutPage,
     fetchRawMissionCards,
@@ -62,11 +63,16 @@ export default function AboutUsPage() {
         [rawMilestones, language]
     );
 
+    const t = useTranslation();
+
     const bannerProps = {
-        title: "About Us",
-        subtitle: "Learn more about Passion Marine and our commitment to excellence",
+        title: t.pages.aboutUs.title,
+        subtitle: t.pages.aboutUs.subtitle,
         backgroundImage: pageData.bannerImage ?? "/images/banner/about-us.webp",
-        breadcrumbItems: [{ label: "Homepage", href: "/" }, { label: "About Us" }],
+        breadcrumbItems: [
+            { label: t.common.homepage, href: "/" },
+            { label: t.nav.aboutUs },
+        ],
     };
 
     const handleCardToggle = (index: number) => {

--- a/src/app/contact-us/page.tsx
+++ b/src/app/contact-us/page.tsx
@@ -6,6 +6,7 @@ import { PrimaryButton } from "@/components/ui/button/PrimaryButton";
 import SocialIcons from "@/components/ui/social/SocialIcons";
 import { ContactForm } from "@/components/ui/contact";
 import { useLanguage } from "@/contexts/LanguageContext";
+import { useTranslation } from "@/i18n";
 import {
     fetchRawContactInfo,
     deriveContactInfo,
@@ -28,10 +29,15 @@ export default function ContactUsPage() {
         [rawData, language]
     );
 
+    const t = useTranslation();
+
     const bannerProps = {
-        title: "Contact Us",
+        title: t.pages.contactUs.title,
         backgroundImage: "/images/banner/contact-us.webp",
-        breadcrumbItems: [{ label: "Homepage", href: "/" }, { label: "Contact Us" }],
+        breadcrumbItems: [
+            { label: t.common.homepage, href: "/" },
+            { label: t.nav.contactUs },
+        ],
     };
 
     const handleGetDirections = () => {
@@ -47,7 +53,7 @@ export default function ContactUsPage() {
                         <div className='contact-info'>
                             <div className='contact-info__content'>
                                 <div className='contact-info__header'>
-                                    <h2 className='contact-info__subtitle'>Get In Touch With</h2>
+                                    <h2 className='contact-info__subtitle'>{t.pages.contactUs.getInTouchWith}</h2>
                                     <h1 className='contact-info__title'>
                                         {contactInfo.companyName}
                                     </h1>
@@ -79,7 +85,7 @@ export default function ContactUsPage() {
                                     />
                                 </div>
                                 <PrimaryButton onClick={handleGetDirections}>
-                                    Get Directions
+                                    {t.pages.contactUs.getDirections}
                                 </PrimaryButton>
                             </div>
                             <div className='contact-info__map'>

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -14,6 +14,7 @@ import { useDialog } from "@/components/ui/dialog";
 import CountUp from "react-countup";
 import { TextReveal } from "@/components/ui/animation/TextReveal";
 import { useLanguage } from "@/contexts/LanguageContext";
+import { useTranslation } from "@/i18n";
 import {
     fetchRawPortfolios,
     derivePortfolioItem,
@@ -64,6 +65,7 @@ const Footer = dynamic(() => import("@/components/ui/layout").then(m => ({ defau
 export default function HeaderPage() {
     const router = useRouter();
     const { language } = useLanguage();
+    const t = useTranslation();
     const [isStatsVisible, setIsStatsVisible] = useState(false);
     const confirmDialog = useDialog();
     const [rawPortfolioData, setRawPortfolioData] = useState<RawPortfolioItem[] | null>(null);
@@ -332,9 +334,9 @@ export default function HeaderPage() {
             <div className='our-services-bg'>
                 <section className='our-services'>
                     <div className='our-services__container'>
-                        <h2 className='our-services__title'>Our Services</h2>
+                        <h2 className='our-services__title'>{t.pages.home.ourServicesTitle}</h2>
                         <TextReveal
-                            text='General Boat Services,'
+                            text={t.pages.home.ourServicesDesc1}
                             className='our-services__description-1'
                             delay={300}
                             lineDelay={0}
@@ -342,7 +344,7 @@ export default function HeaderPage() {
                             as='div'
                         />
                         <TextReveal
-                            text='Engine Repair, Boat Restoration'
+                            text={t.pages.home.ourServicesDesc2}
                             className='our-services__description-2'
                             delay={300}
                             lineDelay={0}
@@ -355,11 +357,11 @@ export default function HeaderPage() {
                 <section className='boat-solutions'>
                     <div className='boat-solutions__container'>
                         <div className='boat-solutions__header'>
-                            <h2 className='boat-solutions__title'>Boat Solutions</h2>
+                            <h2 className='boat-solutions__title'>{t.pages.home.boatSolutionsTitle}</h2>
                             <div className='boat-solutions__button boat-solutions__button--desktop'>
                                 <PrimaryButton
                                     onClick={() => router.push("/services/overview-services")}>
-                                    Overview Services
+                                    {t.nav.overviewServices}
                                 </PrimaryButton>
                             </div>
                         </div>
@@ -391,7 +393,7 @@ export default function HeaderPage() {
                         <div className='boat-solutions__button boat-solutions__button--mobile'>
                             <PrimaryButton
                                 onClick={() => router.push("/services/overview-services")}>
-                                Overview Services
+                                {t.nav.overviewServices}
                             </PrimaryButton>
                         </div>
                     </div>
@@ -454,12 +456,12 @@ export default function HeaderPage() {
                                     <span className='volvo-penta__title--bold'>Passion Marine</span>
                                     <span className='volvo-penta__title--light'>
                                         {" "}
-                                        has been appointed as an authorized service dealer for{" "}
+                                        {t.pages.home.volvoPentaBody}{" "}
                                     </span>
                                     <span className='volvo-penta__title--bold'>Volvo Penta</span>
                                 </h2>
                                 <p className='volvo-penta__subtitle'>
-                                    Connect with us at Petra Marina Pathum Thani
+                                    {t.pages.home.volvoPentaLocation}
                                 </p>
                             </div>
                         </div>
@@ -469,7 +471,7 @@ export default function HeaderPage() {
                                 icon='ph-fill ph-file-text'
                                 noIconRotate={true}
                                 onClick={confirmDialog.open}>
-                                View Document
+                                {t.buttons.viewDocument}
                             </PrimaryButton>
 
                             {/* <PrimaryButton
@@ -484,9 +486,9 @@ export default function HeaderPage() {
                                 onOpenChange={confirmDialog.setIsOpen}
                                 documentImageSrc='/images/home/cer-volvo.png'
                                 documentImageAlt='Volvo Penta Appointment Letter - Letter of Appointment from Alpha Tech and Volvo Penta dated 1st August 2024'
-                                announcementText='Passion Marine has been appointed as an authorized service dealer for Volvo Penta'
+                                announcementText={t.pages.home.volvoPentaAnnouncement}
                                 announcementHighlight={["Passion Marine", "Volvo Penta"]}
-                                locationText='Connect with us at Petra Marina Pathum Thani'
+                                locationText={t.pages.home.volvoPentaLocation}
                                 className='modal-document'
                             />
                         </div>
@@ -496,7 +498,7 @@ export default function HeaderPage() {
 
             <section className='brands'>
                 <div className='brands__container'>
-                    <h2 className='brands__title'>Experienced in leading brands</h2>
+                    <h2 className='brands__title'>{t.pages.home.brandsTitle}</h2>
                     <div className='brands__slider'>
                         <div className='brands__track'>
                             {brandsData.map((item, index) => (
@@ -530,10 +532,10 @@ export default function HeaderPage() {
             <section className='our-portfolio'>
                 <div className='our-portfolio__container'>
                     <div className='our-portfolio__header'>
-                        <h2 className='our-portfolio__title'>Our Portfolio</h2>
+                        <h2 className='our-portfolio__title'>{t.pages.home.portfolioTitle}</h2>
                         <div className='our-portfolio__button'>
                             <PrimaryButton theme='dark' onClick={() => router.push("/portfolio")}>
-                                Explore More
+                                {t.buttons.exploreMore}
                             </PrimaryButton>
                         </div>
                     </div>
@@ -554,7 +556,7 @@ export default function HeaderPage() {
                                             />
                                         )}
                                     </div>
-                                    <div className='our-portfolio__stat-label'>Project</div>
+                                    <div className='our-portfolio__stat-label'>{t.pages.home.projectLabel}</div>
                                 </div>
                                 <div className='our-portfolio__stat-item'>
                                     <div className='our-portfolio__stat-number'>
@@ -567,7 +569,7 @@ export default function HeaderPage() {
                                             />
                                         )}
                                     </div>
-                                    <div className='our-portfolio__stat-label'>Customer</div>
+                                    <div className='our-portfolio__stat-label'>{t.pages.home.customerLabel}</div>
                                 </div>
                             </div>
 
@@ -625,7 +627,7 @@ export default function HeaderPage() {
                                         </span>
                                     </div>
                                     <div className='our-portfolio__review-count'>
-                                        {homePage.reviewCount} Review
+                                        {homePage.reviewCount} {t.pages.home.reviewLabel}
                                     </div>
                                 </div>
                             </div>
@@ -664,7 +666,7 @@ export default function HeaderPage() {
                     {/* Mobile Explore More Button */}
                     <div className='our-portfolio__mobile-button'>
                         <PrimaryButton theme='dark' onClick={() => router.push("/portfolio")}>
-                            Explore More
+                            {t.buttons.exploreMore}
                         </PrimaryButton>
                     </div>
                 </div>
@@ -673,10 +675,10 @@ export default function HeaderPage() {
             <section className='our-latest-news'>
                 <div className='our-latest-news__container'>
                     <div className='our-latest-news__header'>
-                        <h2 className='our-latest-news__title'>Our Latest News</h2>
+                        <h2 className='our-latest-news__title'>{t.pages.home.latestNewsTitle}</h2>
                         <div className='our-latest-news__button our-latest-news__button--desktop'>
                             <PrimaryButton onClick={() => router.push("/news")}>
-                                View All
+                                {t.buttons.viewAll}
                             </PrimaryButton>
                         </div>
                     </div>
@@ -706,7 +708,7 @@ export default function HeaderPage() {
                         />
                     </div>
                     <div className='our-latest-news__button our-latest-news__button--mobile'>
-                        <PrimaryButton onClick={() => router.push("/news")}>View All</PrimaryButton>
+                        <PrimaryButton onClick={() => router.push("/news")}>{t.buttons.viewAll}</PrimaryButton>
                     </div>
                 </div>
             </section>

--- a/src/app/news/[id]/page.tsx
+++ b/src/app/news/[id]/page.tsx
@@ -7,6 +7,7 @@ import "@/styles/page/news/news-detail.scss";
 import { PrimaryButton } from "@/components/ui/button/PrimaryButton";
 import SocialIcons from "@/components/ui/social/SocialIcons";
 import { useLanguage } from "@/contexts/LanguageContext";
+import { useTranslation } from "@/i18n";
 import {
     fetchRawArticleById,
     deriveNewsDetailItem,
@@ -38,12 +39,14 @@ export default function NewsDetailPage({ params }: { params: Promise<{ id: strin
         [rawArticle, language]
     );
 
+    const t = useTranslation();
+
     if (rawArticle === undefined) {
-        return <div>Loading...</div>;
+        return <div>{t.common.loading}</div>;
     }
 
     if (!newsDetail) {
-        return <div>News not found</div>;
+        return <div>{t.pages.news.notFound}</div>;
     }
 
     return (
@@ -99,7 +102,7 @@ export default function NewsDetailPage({ params }: { params: Promise<{ id: strin
                     <div className='container'>
                         <div className='flex items-center justify-between lg:px-16 xl:px-28'>
                             <PrimaryButton theme='revert' onClick={() => window.history.back()}>
-                                Back
+                                {t.common.back}
                             </PrimaryButton>
                             <SocialIcons
                                 showLabel={true}

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -6,6 +6,7 @@ import "@/styles/page/news/news.scss";
 import { NewsCard } from "@/components/ui/cards";
 import Pagination from "@/components/ui/navigation/Pagination";
 import { useLanguage } from "@/contexts/LanguageContext";
+import { useTranslation } from "@/i18n";
 import {
     fetchRawArticles,
     deriveNewsItem,
@@ -20,10 +21,15 @@ export default function NewsPage() {
     const [rawArticles, setRawArticles] = useState<RawArticleItem[] | null>(null);
     const itemsPerPage = 9;
 
+    const t = useTranslation();
+
     const bannerProps = {
-        title: "News & Activity",
+        title: t.pages.news.title,
         backgroundImage: "/images/banner/news.webp",
-        breadcrumbItems: [{ label: "Homepage", href: "/" }, { label: "News & Activity" }],
+        breadcrumbItems: [
+            { label: t.common.homepage, href: "/" },
+            { label: t.pages.news.title },
+        ],
     };
 
     useEffect(() => {

--- a/src/app/portfolio/[id]/page.tsx
+++ b/src/app/portfolio/[id]/page.tsx
@@ -11,6 +11,7 @@ import SocialIcons from "@/components/ui/social/SocialIcons";
 import { SwiperSlider } from "@/components/ui/media";
 import { SwiperSlideData } from "@/components/ui/media/SwiperSlider";
 import { useLanguage } from "@/contexts/LanguageContext";
+import { useTranslation } from "@/i18n";
 import {
     fetchRawPortfolios,
     derivePortfolioDetail,
@@ -40,8 +41,10 @@ export default function PortfolioDetailPage({ params }: { params: Promise<{ id: 
         return derivePortfolioDetail(rawItem, rawData, language);
     }, [resolvedParams, rawData, language]);
 
+    const t = useTranslation();
+
     if (!portfolioDetailData) {
-        return <div>Loading...</div>;
+        return <div>{t.common.loading}</div>;
     }
 
     return (
@@ -60,7 +63,7 @@ export default function PortfolioDetailPage({ params }: { params: Promise<{ id: 
                                 </p>
 
                                 <div className='text-h6 mb-4 font-semibold text-[var(--blue-500)] xl:mb-6'>
-                                    Model: {portfolioDetailData.model}
+                                    {t.pages.portfolio.model} {portfolioDetailData.model}
                                 </div>
                                 <div className='flex justify-center gap-4'>
                                     {portfolioDetailData.brandLogos.map((logo, index) => (
@@ -112,7 +115,7 @@ export default function PortfolioDetailPage({ params }: { params: Promise<{ id: 
                     <div className='container'>
                         <div className='flex items-center justify-between lg:px-16 xl:px-28'>
                             <PrimaryButton theme='revert' onClick={() => window.history.back()}>
-                                Back
+                                {t.common.back}
                             </PrimaryButton>
                             <SocialIcons
                                 showLabel={true}
@@ -135,7 +138,7 @@ export default function PortfolioDetailPage({ params }: { params: Promise<{ id: 
                         <div className='grid grid-cols-12'>
                             <div className='col-span-12 xl:col-span-10 xl:col-start-2'>
                                 <h2 className='text-h2 mb-8 text-[var(--blue-500)]'>
-                                    Services provided
+                                    {t.pages.portfolio.servicesProvided}
                                 </h2>
                                 <div className='portfolio-services__swiper'>
                                     <ServicesSwiper
@@ -180,7 +183,7 @@ export default function PortfolioDetailPage({ params }: { params: Promise<{ id: 
                             <div className='grid grid-cols-12'>
                                 <div className='col-span-12'>
                                     <h2 className='text-h2 mb-8 text-[var(--blue-500)]'>
-                                        Other portfolio
+                                        {t.pages.portfolio.otherPortfolio}
                                     </h2>
 
                                     <div className='portfolio-services__swiper'>

--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useMemo } from "react";
 import { useLanguage } from "@/contexts/LanguageContext";
+import { useTranslation } from "@/i18n";
 import MainLayout from "@/components/ui/layout/MainLayout";
 import { PortfolioCard } from "@/components/ui/cards/PortfolioCard";
 import Pagination from "@/components/ui/navigation/Pagination";
@@ -19,10 +20,15 @@ export default function PortfolioPage() {
     const itemsPerPage = 9;
     const [rawData, setRawData] = useState<RawPortfolioItem[] | null>(null);
 
+    const t = useTranslation();
+
     const bannerProps = {
-        title: "Portfolio",
+        title: t.pages.portfolio.title,
         backgroundImage: "/images/banner/portfolio.webp",
-        breadcrumbItems: [{ label: "Homepage", href: "/" }, { label: "Portfolio" }],
+        breadcrumbItems: [
+            { label: t.common.homepage, href: "/" },
+            { label: t.pages.portfolio.title },
+        ],
     };
 
     useEffect(() => {

--- a/src/app/services/aesthetic-solutions/page.tsx
+++ b/src/app/services/aesthetic-solutions/page.tsx
@@ -6,6 +6,7 @@ import "@/styles/page/aesthetic-solutions.scss";
 import { GallerySlider } from "@/components/ui/media";
 import { BoatColorCustomizer } from "@/components/ui/aesthetic";
 import { useLanguage } from "@/contexts/LanguageContext";
+import { useTranslation } from "@/i18n";
 import {
     fetchRawAestheticPage,
     fetchRawServices,
@@ -77,14 +78,16 @@ export default function AestheticSolutionsPage() {
     }, []);
 
 
+    const t = useTranslation();
+
     const bannerProps = {
-        title: "Aesthetic Solutions",
+        title: t.nav.aestheticSolutions,
         backgroundImage: "/images/banner/aesthetic-solutions.webp",
         breadcrumbItems: [
-            { label: "Homepage", href: "/" },
-            { label: "Our Services" },
-            { label: "Overview Services", href: "/services/overview-services" },
-            { label: "Aesthetic Solutions" },
+            { label: t.common.homepage, href: "/" },
+            { label: t.nav.ourServices },
+            { label: t.nav.overviewServices, href: "/services/overview-services" },
+            { label: t.nav.aestheticSolutions },
         ],
     };
 

--- a/src/app/services/engineering-solutions/page.tsx
+++ b/src/app/services/engineering-solutions/page.tsx
@@ -5,6 +5,7 @@ import MainLayout from "@/components/ui/layout/MainLayout";
 import "@/styles/page/engineering-solutions.scss";
 import { GallerySlider } from "@/components/ui/media";
 import { useLanguage } from "@/contexts/LanguageContext";
+import { useTranslation } from "@/i18n";
 import {
     fetchRawEngineeringPage,
     fetchRawServices,
@@ -71,14 +72,16 @@ export default function EngineeringSolutionsPage() {
 
 
 
+    const t = useTranslation();
+
     const bannerProps = {
-        title: "Engineering Solutions",
+        title: t.nav.engineeringSolutions,
         backgroundImage: "/images/banner/engineering-solutions.webp",
         breadcrumbItems: [
-            { label: "Homepage", href: "/" },
-            { label: "Our Services" },
-            { label: "Overview Services", href: "/services/overview-services" },
-            { label: "Engineering Solutions" },
+            { label: t.common.homepage, href: "/" },
+            { label: t.nav.ourServices },
+            { label: t.nav.overviewServices, href: "/services/overview-services" },
+            { label: t.nav.engineeringSolutions },
         ],
     };
 

--- a/src/app/services/overview-services/page.tsx
+++ b/src/app/services/overview-services/page.tsx
@@ -7,6 +7,7 @@ import { ServiceCard } from "@/components/ui/cards";
 import { useRouter } from "next/navigation";
 import { useAOS } from "@/hooks/useAOS";
 import { useLanguage } from "@/contexts/LanguageContext";
+import { useTranslation } from "@/i18n";
 import {
     fetchRawServicesPage,
     fetchRawServicesPageStats,
@@ -54,13 +55,15 @@ export default function OverviewServicesPage() {
         if (rawFeatures) setFeatures(deriveServicesPageFeatures(rawFeatures, language));
     }, [rawFeatures, language]);
 
+    const t = useTranslation();
+
     const bannerProps = {
-        title: "Overview Services",
+        title: t.pages.overviewServices.title,
         backgroundImage: "/images/banner/overview-services.webp",
         breadcrumbItems: [
-            { label: "Homepage", href: "/" },
-            { label: "Our Services" },
-            { label: "Overview Services" },
+            { label: t.common.homepage, href: "/" },
+            { label: t.nav.ourServices },
+            { label: t.nav.overviewServices },
         ],
     };
 
@@ -126,7 +129,7 @@ export default function OverviewServicesPage() {
                             data-aos-delay='200'
                             data-aos-duration='800'
                             data-aos-easing='ease-out-cubic'>
-                            Comprehensive Services
+                            {t.pages.overviewServices.comprehensiveServices}
                         </h2>
                         <div className='grid grid-cols-1 gap-8 text-center md:grid-cols-2 md:text-left lg:grid-cols-4'>
                             {features.map((feature, index) => (
@@ -169,8 +172,8 @@ export default function OverviewServicesPage() {
                                 data-aos-duration='800'
                                 data-aos-easing='ease-out-cubic'>
                                 <ServiceCard
-                                    title='Engineering Solutions'
-                                    description='Your Trusted Partner in After-Sales & Maintenance'
+                                    title={t.pages.overviewServices.engineering.title}
+                                    description={t.pages.overviewServices.engineering.description}
                                     imageSrc='/images/our-services/overview-services/engineering-solutions.webp'
                                     imageAlt='Engineering Solutions'
                                     icon={<i className='ph ph-arrow-up-right'></i>}
@@ -185,8 +188,8 @@ export default function OverviewServicesPage() {
                                 data-aos-duration='800'
                                 data-aos-easing='ease-out-cubic'>
                                 <ServiceCard
-                                    title='Aesthetic Solutions'
-                                    description="Elevate Your Boat's Style and Comfort"
+                                    title={t.pages.overviewServices.aesthetic.title}
+                                    description={t.pages.overviewServices.aesthetic.description}
                                     imageSrc='/images/our-services/overview-services/aesthetic-solutions.webp'
                                     imageAlt='Aesthetic Solutions'
                                     icon={<i className='ph ph-arrow-up-right'></i>}

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -1,11 +1,19 @@
+"use client";
+
+import { useTranslation } from "@/i18n";
 import MainLayout from "@/components/ui/layout/MainLayout";
 
 export default function ServicesPage() {
+    const t = useTranslation();
+
     const bannerProps = {
-        title: "Our Services",
-        subtitle: "Comprehensive marine solutions",
+        title: t.pages.services.title,
+        subtitle: t.pages.services.subtitle,
         backgroundImage: "/images/banner/overview-services.webp",
-        breadcrumbItems: [{ label: "Homepage", href: "/" }, { label: "Our Services" }],
+        breadcrumbItems: [
+            { label: t.common.homepage, href: "/" },
+            { label: t.nav.ourServices },
+        ],
     };
 
     return (
@@ -14,13 +22,12 @@ export default function ServicesPage() {
                 <section className='section section--space-top'>
                     <div className='container'>
                         <h1 className='text-h1 font-semibold uppercase text-[var(--blue-500)]'>
-                            Our Services
+                            {t.pages.services.title}
                         </h1>
                         <div className='mt-4 flex justify-end'>
                             <div className='w-full lg:w-9/12'>
                                 <p className='text-h5 mb-4 text-left font-normal text-[var(--grey-600)]'>
-                                    Discover our comprehensive range of marine services designed to
-                                    enhance your boating experience.
+                                    {t.pages.services.description}
                                 </p>
                             </div>
                         </div>

--- a/src/components/ui/cards/NewsCard.tsx
+++ b/src/components/ui/cards/NewsCard.tsx
@@ -3,6 +3,7 @@
 import { cn } from "@/lib/utils";
 import Image from "next/image";
 import Link from "next/link";
+import { useTranslation } from "@/i18n";
 //components
 import { ReadMoreButton } from "@/components/ui/button/ReadMoreButton";
 
@@ -27,6 +28,8 @@ const NewsCard = ({
     href = "#",
     variant = "default",
 }: NewsCardProps) => {
+    const t = useTranslation();
+
     return (
         <div className={cn("card-news", `card-news--${variant}`, className)}>
             <Link href={href} className='card-news__link'>
@@ -49,7 +52,7 @@ const NewsCard = ({
                     </div>
 
                     <div className='card-news__footer'>
-                        <ReadMoreButton>Read More</ReadMoreButton>
+                        <ReadMoreButton>{t.buttons.readMore}</ReadMoreButton>
                     </div>
                 </div>
             </Link>

--- a/src/components/ui/contact/ContactForm.tsx
+++ b/src/components/ui/contact/ContactForm.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { BookNowButton } from "@/components/ui/button/BookNowButton";
 import ContactFormModal from "./ContactFormModal";
 import PDPAModal from "./PDPAModal";
+import { useTranslation } from "@/i18n";
 
 export interface ContactFormData {
     firstName: string;
@@ -20,6 +21,8 @@ interface ContactFormProps {
 }
 
 export default function ContactForm({ onSubmit }: ContactFormProps) {
+    const t = useTranslation();
+
     const [formData, setFormData] = useState<ContactFormData>({
         firstName: "",
         lastName: "",
@@ -115,20 +118,20 @@ export default function ContactForm({ onSubmit }: ContactFormProps) {
     const validateForm = (): boolean => {
         const newErrors: Partial<Record<keyof ContactFormData, string>> = {};
 
-        if (!formData.firstName.trim()) newErrors.firstName = "First name is required";
-        if (!formData.lastName.trim()) newErrors.lastName = "Last name is required";
+        if (!formData.firstName.trim()) newErrors.firstName = t.contactForm.errors.firstName;
+        if (!formData.lastName.trim()) newErrors.lastName = t.contactForm.errors.lastName;
 
         if (!formData.email.trim()) {
-            newErrors.email = "Email is required";
+            newErrors.email = t.contactForm.errors.emailRequired;
         } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.email)) {
-            newErrors.email = "Please enter a valid email";
+            newErrors.email = t.contactForm.errors.emailInvalid;
         }
 
-        if (!formData.subject.trim()) newErrors.subject = "Subject is required";
-        if (!formData.message.trim()) newErrors.message = "Message is required";
+        if (!formData.subject.trim()) newErrors.subject = t.contactForm.errors.subject;
+        if (!formData.message.trim()) newErrors.message = t.contactForm.errors.message;
 
         if (!formData.acceptTerms) {
-            newErrors.acceptTerms = "You must accept the terms and conditions";
+            newErrors.acceptTerms = t.contactForm.errors.acceptTerms;
         }
 
         setErrors(newErrors);
@@ -145,8 +148,8 @@ export default function ContactForm({ onSubmit }: ContactFormProps) {
         // Show loading modal immediately
         setModalData({
             type: "loading",
-            title: "Sending Your Message",
-            message: "Please wait while we process your request. This may take a few seconds.",
+            title: t.contactForm.toast.loadingTitle,
+            message: t.contactForm.toast.loadingMessage,
         });
         setModalOpen(true);
 
@@ -216,9 +219,8 @@ export default function ContactForm({ onSubmit }: ContactFormProps) {
 
             setModalData({
                 type: "success",
-                title: "Message Sent Successfully!",
-                message:
-                    "Thank you for contacting Passion Marine. We have received your message and will respond to you as soon as possible.",
+                title: t.contactForm.toast.successTitle,
+                message: t.contactForm.toast.successMessage,
             });
             setModalOpen(true);
         } catch (error) {
@@ -227,13 +229,12 @@ export default function ContactForm({ onSubmit }: ContactFormProps) {
             const errorMessage =
                 error instanceof Error
                     ? error.message
-                    : "An error occurred. Please try again later.";
+                    : t.contactForm.toast.errorFallback;
 
             setModalData({
                 type: "error",
-                title: "Failed to Send Message",
-                message:
-                    "We encountered an issue while sending your message. Please try again or contact us directly.",
+                title: t.contactForm.toast.errorTitle,
+                message: t.contactForm.toast.errorMessage,
                 errorDetails: errorMessage,
             });
             setModalOpen(true);
@@ -245,18 +246,15 @@ export default function ContactForm({ onSubmit }: ContactFormProps) {
     return (
         <div className='contact-form'>
             <div className='contact-form__header'>
-                <h2 className='contact-form__title'>Contact Form</h2>
-                <p className='contact-form__description'>
-                    Your questions and comments are important to us. Please use the form below to
-                    contact and we will get back to you as soon as possible.
-                </p>
+                <h2 className='contact-form__title'>{t.contactForm.title}</h2>
+                <p className='contact-form__description'>{t.contactForm.description}</p>
             </div>
 
             <form onSubmit={handleSubmit} className='contact-form__form'>
                 <div className='contact-form__row'>
                     <div className='contact-form__field'>
                         <label className='contact-form__label'>
-                            First Name <span className='contact-form__required'>*</span>
+                            {t.contactForm.firstName} <span className='contact-form__required'>*</span>
                         </label>
                         <input
                             type='text'
@@ -272,7 +270,7 @@ export default function ContactForm({ onSubmit }: ContactFormProps) {
 
                     <div className='contact-form__field'>
                         <label className='contact-form__label'>
-                            Last Name <span className='contact-form__required'>*</span>
+                            {t.contactForm.lastName} <span className='contact-form__required'>*</span>
                         </label>
                         <input
                             type='text'
@@ -290,7 +288,7 @@ export default function ContactForm({ onSubmit }: ContactFormProps) {
                 <div className='contact-form__row'>
                     <div className='contact-form__field'>
                         <label className='contact-form__label'>
-                            Email <span className='contact-form__required'>*</span>
+                            {t.contactForm.email} <span className='contact-form__required'>*</span>
                         </label>
                         <input
                             type='email'
@@ -305,7 +303,7 @@ export default function ContactForm({ onSubmit }: ContactFormProps) {
                     </div>
 
                     <div className='contact-form__field'>
-                        <label className='contact-form__label'>Telephone</label>
+                        <label className='contact-form__label'>{t.contactForm.telephone}</label>
                         <input
                             type='tel'
                             name='telephone'
@@ -320,7 +318,7 @@ export default function ContactForm({ onSubmit }: ContactFormProps) {
 
                 <div className='contact-form__field'>
                     <label className='contact-form__label'>
-                        Subject <span className='contact-form__required'>*</span>
+                        {t.contactForm.subject} <span className='contact-form__required'>*</span>
                     </label>
                     <input
                         type='text'
@@ -336,7 +334,7 @@ export default function ContactForm({ onSubmit }: ContactFormProps) {
 
                 <div className='contact-form__field'>
                     <label className='contact-form__label'>
-                        Message <span className='contact-form__required'>*</span>
+                        {t.contactForm.message} <span className='contact-form__required'>*</span>
                     </label>
                     <textarea
                         name='message'
@@ -360,7 +358,7 @@ export default function ContactForm({ onSubmit }: ContactFormProps) {
                             className='contact-form__checkbox-input'
                         />
                         <label htmlFor='acceptTerms' className='contact-form__checkbox-label'>
-                            I have read and accepted terms and conditions specified in the{" "}
+                            {t.contactForm.pdpa.prefix}{" "}
                             <button
                                 type='button'
                                 onClick={e => {
@@ -368,10 +366,9 @@ export default function ContactForm({ onSubmit }: ContactFormProps) {
                                     setPdpaModalOpen(true);
                                 }}
                                 className='contact-form__link contact-form__link--button'>
-                                PDPA Policy
+                                {t.contactForm.pdpa.policyLink}
                             </button>{" "}
-                            and do hereby consent to the collecting, processing and/or disclosing of
-                            the personal data provided by me to fulfil the above-said purposes.
+                            {t.contactForm.pdpa.suffix}
                         </label>
                     </div>
                     {errors.acceptTerms && (
@@ -385,7 +382,7 @@ export default function ContactForm({ onSubmit }: ContactFormProps) {
                         variant='default'
                         showIcon={false}
                         disabled={isSubmitting}>
-                        {isSubmitting ? "Sending..." : "Submit"}
+                        {isSubmitting ? t.contactForm.submitting : t.contactForm.submit}
                     </BookNowButton>
                 </div>
             </form>

--- a/src/components/ui/contact/ContactFormModal.tsx
+++ b/src/components/ui/contact/ContactFormModal.tsx
@@ -2,6 +2,7 @@
 
 import { Dialog, DialogContent, DialogClose } from "@/components/ui/dialog";
 import { BookNowButton } from "@/components/ui/button/BookNowButton";
+import { useTranslation } from "@/i18n";
 
 interface ContactFormModalProps {
     open: boolean;
@@ -20,6 +21,7 @@ export default function ContactFormModal({
     message,
     errorDetails,
 }: ContactFormModalProps) {
+    const t = useTranslation();
     const isSuccess = type === "success";
     const isLoading = type === "loading";
 
@@ -80,7 +82,7 @@ export default function ContactFormModal({
                                         window.location.reload();
                                     }
                                 }}>
-                                {isSuccess ? "Close" : "Try Again"}
+                                {isSuccess ? t.contactForm.modal.close : t.contactForm.modal.tryAgain}
                             </BookNowButton>
                         </div>
                     )}

--- a/src/components/ui/layout/Footer.tsx
+++ b/src/components/ui/layout/Footer.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/utils";
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { useTranslation } from "@/i18n";
 //components
 import { PrimaryButton } from "@/components/ui/button/PrimaryButton";
 
@@ -13,6 +14,7 @@ export interface FooterProps {
 
 const Footer = ({ className }: FooterProps) => {
     const router = useRouter();
+    const t = useTranslation();
 
     const scrollToTop = () => {
         window.scrollTo({
@@ -43,14 +45,14 @@ const Footer = ({ className }: FooterProps) => {
                         </div>
                         <div className='footer__column-contact'>
                             <PrimaryButton theme='dark' onClick={() => router.push("/contact-us")}>
-                                Contact Us
+                                {t.footer.contactUsButton}
                             </PrimaryButton>
                         </div>
                     </div>
 
                     {/* Middle Column - Contact */}
                     <div className='footer__column'>
-                        <h3 className='footer__column-title'>Contact</h3>
+                        <h3 className='footer__column-title'>{t.footer.contact}</h3>
                         <div className='footer__contact'>
                             <div className='footer__contact-item'>
                                 <div className='footer__contact-item-title'>Phone:</div>
@@ -81,7 +83,7 @@ const Footer = ({ className }: FooterProps) => {
 
                     {/* Right Column - Social */}
                     <div className='footer__column'>
-                        <h3 className='footer__column-title'>Social</h3>
+                        <h3 className='footer__column-title'>{t.footer.social}</h3>
                         <div className='footer__social'>
                             {/* <Link
                                 href='https://facebook.com/passionmarine'

--- a/src/components/ui/layout/Header.tsx
+++ b/src/components/ui/layout/Header.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import Image from "next/image";
 import { useLanguage } from "@/contexts/LanguageContext";
+import { useTranslation } from "@/i18n";
 
 export interface HeaderProps {
     className?: string;
@@ -31,21 +32,22 @@ const Header = ({ className, theme = "white" }: HeaderProps) => {
     const [isHovered, setIsHovered] = useState(false);
     const { language, setLanguage } = useLanguage();
     const currentLanguage = language.toUpperCase() as "EN" | "TH";
+    const t = useTranslation();
 
     // Navigation items
     const navItems: NavItem[] = [
         {
-            label: "About Us",
+            label: t.nav.aboutUs,
             href: "/about-us",
         },
         {
-            label: "Our Services",
+            label: t.nav.ourServices,
             href: "/services",
             hasDropdown: true,
             dropdownItems: [
-                { label: "Overview Services", href: "/services/overview-services" },
-                { label: "Engineering Solutions", href: "/services/engineering-solutions" },
-                { label: "Aesthetic Solutions", href: "/services/aesthetic-solutions" },
+                { label: t.nav.overviewServices, href: "/services/overview-services" },
+                { label: t.nav.engineeringSolutions, href: "/services/engineering-solutions" },
+                { label: t.nav.aestheticSolutions, href: "/services/aesthetic-solutions" },
             ],
         },
         // {
@@ -53,15 +55,15 @@ const Header = ({ className, theme = "white" }: HeaderProps) => {
         //     href: "/charter",
         // },
         {
-            label: "Portfolio",
+            label: t.nav.portfolio,
             href: "/portfolio",
         },
         {
-            label: "News and Activities",
+            label: t.nav.newsAndActivities,
             href: "/news",
         },
         {
-            label: "Contact Us",
+            label: t.nav.contactUs,
             href: "/contact-us",
         },
     ];

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,10 @@
+import { useLanguage } from "@/contexts/LanguageContext";
+import { translations } from "./translations";
+
+export { translations } from "./translations";
+export type { Language } from "./translations";
+
+export function useTranslation() {
+    const { language } = useLanguage();
+    return translations[language];
+}

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -1,0 +1,263 @@
+export const translations = {
+    en: {
+        common: {
+            homepage: "Homepage",
+            loading: "Loading...",
+            back: "Back",
+        },
+
+        buttons: {
+            readMore: "Read More",
+            viewAll: "View All",
+            exploreMore: "Explore More",
+            viewDocument: "View Document",
+        },
+
+        nav: {
+            aboutUs: "About Us",
+            ourServices: "Our Services",
+            overviewServices: "Overview Services",
+            engineeringSolutions: "Engineering Solutions",
+            aestheticSolutions: "Aesthetic Solutions",
+            portfolio: "Portfolio",
+            newsAndActivities: "News and Activities",
+            contactUs: "Contact Us",
+        },
+
+        footer: {
+            contact: "Contact",
+            social: "Social",
+            contactUsButton: "Contact Us",
+        },
+
+        contactForm: {
+            title: "Contact Form",
+            description:
+                "Your questions and comments are important to us. Please use the form below to contact and we will get back to you as soon as possible.",
+            firstName: "First Name",
+            lastName: "Last Name",
+            email: "Email",
+            telephone: "Telephone",
+            subject: "Subject",
+            message: "Message",
+            errors: {
+                firstName: "First name is required",
+                lastName: "Last name is required",
+                emailRequired: "Email is required",
+                emailInvalid: "Please enter a valid email",
+                subject: "Subject is required",
+                message: "Message is required",
+                acceptTerms: "You must accept the terms and conditions",
+            },
+            toast: {
+                loadingTitle: "Sending Your Message",
+                loadingMessage:
+                    "Please wait while we process your request. This may take a few seconds.",
+                successTitle: "Message Sent Successfully!",
+                successMessage:
+                    "Thank you for contacting Passion Marine. We have received your message and will respond to you as soon as possible.",
+                errorTitle: "Failed to Send Message",
+                errorMessage:
+                    "We encountered an issue while sending your message. Please try again or contact us directly.",
+                errorFallback: "An error occurred. Please try again later.",
+            },
+            pdpa: {
+                prefix: "I have read and accepted terms and conditions specified in the",
+                policyLink: "PDPA Policy",
+                suffix: "and do hereby consent to the collecting, processing and/or disclosing of the personal data provided by me to fulfil the above-said purposes.",
+            },
+            submit: "Submit",
+            submitting: "Sending...",
+            modal: {
+                close: "Close",
+                tryAgain: "Try Again",
+            },
+        },
+
+        pages: {
+            services: {
+                title: "Our Services",
+                subtitle: "Comprehensive marine solutions",
+                description:
+                    "Discover our comprehensive range of marine services designed to enhance your boating experience.",
+            },
+            overviewServices: {
+                title: "Overview Services",
+                comprehensiveServices: "Comprehensive Services",
+                engineering: {
+                    title: "Engineering Solutions",
+                    description: "Your Trusted Partner in After-Sales & Maintenance",
+                },
+                aesthetic: {
+                    title: "Aesthetic Solutions",
+                    description: "Elevate Your Boat's Style and Comfort",
+                },
+            },
+            aboutUs: {
+                title: "About Us",
+                subtitle: "Learn more about Passion Marine and our commitment to excellence",
+            },
+            contactUs: {
+                title: "Contact Us",
+                getInTouchWith: "Get In Touch With",
+                getDirections: "Get Directions",
+            },
+            news: {
+                title: "News & Activity",
+                notFound: "News not found",
+            },
+            portfolio: {
+                title: "Portfolio",
+                model: "Model:",
+                servicesProvided: "Services provided",
+                otherPortfolio: "Other portfolio",
+            },
+            home: {
+                ourServicesTitle: "Our Services",
+                ourServicesDesc1: "General Boat Services,",
+                ourServicesDesc2: "Engine Repair, Boat Restoration",
+                boatSolutionsTitle: "Boat Solutions",
+                volvoPentaBody: "has been appointed as an authorized service dealer for",
+                volvoPentaLocation: "Connect with us at Petra Marina Pathum Thani",
+                volvoPentaAnnouncement: "Passion Marine has been appointed as an authorized service dealer for Volvo Penta",
+                brandsTitle: "Experienced in leading brands",
+                portfolioTitle: "Our Portfolio",
+                projectLabel: "Project",
+                customerLabel: "Customer",
+                reviewLabel: "Review",
+                latestNewsTitle: "Our Latest News",
+            },
+        },
+    },
+
+    th: {
+        common: {
+            homepage: "หน้าแรก",
+            loading: "กำลังโหลด...",
+            back: "ย้อนกลับ",
+        },
+
+        buttons: {
+            readMore: "อ่านเพิ่มเติม",
+            viewAll: "ดูทั้งหมด",
+            exploreMore: "ดูเพิ่มเติม",
+            viewDocument: "ดูเอกสาร",
+        },
+
+        nav: {
+            aboutUs: "เกี่ยวกับเรา",
+            ourServices: "บริการของเรา",
+            overviewServices: "ภาพรวมบริการ",
+            engineeringSolutions: "วิศวกรรมโซลูชัน",
+            aestheticSolutions: "สุนทรียภาพโซลูชัน",
+            portfolio: "ผลงาน",
+            newsAndActivities: "ข่าวสารและกิจกรรม",
+            contactUs: "ติดต่อเรา",
+        },
+
+        footer: {
+            contact: "ติดต่อ",
+            social: "โซเชียล",
+            contactUsButton: "ติดต่อเรา",
+        },
+
+        contactForm: {
+            title: "แบบฟอร์มติดต่อ",
+            description:
+                "คำถามและความคิดเห็นของท่านมีความสำคัญต่อเรา กรุณาใช้แบบฟอร์มด้านล่างเพื่อติดต่อ และเราจะติดต่อกลับโดยเร็วที่สุด",
+            firstName: "ชื่อ",
+            lastName: "นามสกุล",
+            email: "อีเมล",
+            telephone: "เบอร์โทรศัพท์",
+            subject: "หัวข้อ",
+            message: "ข้อความ",
+            errors: {
+                firstName: "กรุณากรอกชื่อ",
+                lastName: "กรุณากรอกนามสกุล",
+                emailRequired: "กรุณากรอกอีเมล",
+                emailInvalid: "กรุณากรอกอีเมลให้ถูกต้อง",
+                subject: "กรุณากรอกหัวข้อ",
+                message: "กรุณากรอกข้อความ",
+                acceptTerms: "กรุณายอมรับข้อกำหนดและเงื่อนไข",
+            },
+            toast: {
+                loadingTitle: "กำลังส่งข้อความของคุณ",
+                loadingMessage: "กรุณารอสักครู่ขณะที่เรากำลังดำเนินการ อาจใช้เวลาสักครู่",
+                successTitle: "ส่งข้อความสำเร็จ!",
+                successMessage:
+                    "ขอบคุณที่ติดต่อ Passion Marine เราได้รับข้อความของคุณแล้วและจะตอบกลับโดยเร็วที่สุด",
+                errorTitle: "ส่งข้อความไม่สำเร็จ",
+                errorMessage: "เกิดปัญหาในการส่งข้อความ กรุณาลองใหม่หรือติดต่อเราโดยตรง",
+                errorFallback: "เกิดข้อผิดพลาด กรุณาลองใหม่อีกครั้ง",
+            },
+            pdpa: {
+                prefix: "ข้าพเจ้าได้อ่านและยอมรับข้อกำหนดและเงื่อนไขที่ระบุใน",
+                policyLink: "นโยบาย PDPA",
+                suffix: "และยินยอมให้มีการเก็บรวบรวม ประมวลผล และ/หรือเปิดเผยข้อมูลส่วนบุคคลที่ข้าพเจ้าให้ไว้เพื่อวัตถุประสงค์ดังกล่าว",
+            },
+            submit: "ส่ง",
+            submitting: "กำลังส่ง...",
+            modal: {
+                close: "ปิด",
+                tryAgain: "ลองอีกครั้ง",
+            },
+        },
+
+        pages: {
+            services: {
+                title: "บริการของเรา",
+                subtitle: "โซลูชันทางทะเลครบวงจร",
+                description:
+                    "ค้นพบบริการทางทะเลที่ครอบคลุมของเรา ออกแบบมาเพื่อยกระดับประสบการณ์การใช้เรือของคุณ",
+            },
+            overviewServices: {
+                title: "ภาพรวมบริการ",
+                comprehensiveServices: "บริการครบวงจร",
+                engineering: {
+                    title: "วิศวกรรมโซลูชัน",
+                    description: "พันธมิตรที่เชื่อถือได้สำหรับงานหลังการขายและบำรุงรักษา",
+                },
+                aesthetic: {
+                    title: "สุนทรียภาพโซลูชัน",
+                    description: "ยกระดับสไตล์และความสะดวกสบายให้กับเรือของคุณ",
+                },
+            },
+            aboutUs: {
+                title: "เกี่ยวกับเรา",
+                subtitle: "เรียนรู้เพิ่มเติมเกี่ยวกับ Passion Marine และความมุ่งมั่นสู่ความเป็นเลิศของเรา",
+            },
+            contactUs: {
+                title: "ติดต่อเรา",
+                getInTouchWith: "ติดต่อกับ",
+                getDirections: "เส้นทาง",
+            },
+            news: {
+                title: "ข่าวสารและกิจกรรม",
+                notFound: "ไม่พบข่าวสาร",
+            },
+            portfolio: {
+                title: "ผลงาน",
+                model: "รุ่น:",
+                servicesProvided: "บริการที่ให้",
+                otherPortfolio: "ผลงานอื่นๆ",
+            },
+            home: {
+                ourServicesTitle: "บริการของเรา",
+                ourServicesDesc1: "บริการเรือทั่วไป,",
+                ourServicesDesc2: "ซ่อมเครื่องยนต์, บูรณะเรือ",
+                boatSolutionsTitle: "โซลูชันเรือ",
+                volvoPentaBody: "ได้รับการแต่งตั้งเป็นตัวแทนบริการที่ได้รับอนุญาตสำหรับ",
+                volvoPentaLocation: "ติดต่อเราได้ที่ Petra Marina ปทุมธานี",
+                volvoPentaAnnouncement: "Passion Marine ได้รับการแต่งตั้งเป็นตัวแทนบริการที่ได้รับอนุญาตสำหรับ Volvo Penta",
+                brandsTitle: "ชำนาญในแบรนด์ชั้นนำ",
+                portfolioTitle: "ผลงานของเรา",
+                projectLabel: "โครงการ",
+                customerLabel: "ลูกค้า",
+                reviewLabel: "รีวิว",
+                latestNewsTitle: "ข่าวสารล่าสุด",
+            },
+        },
+    },
+} as const;
+
+export type Language = keyof typeof translations;


### PR DESCRIPTION
Create src/i18n/translations.ts with en/th translations organized by namespace (nav, footer, buttons, contactForm, pages.*). Add useTranslation() hook and replace all inline th ? "..." : "..." ternaries across Header, Footer, ContactForm, ContactFormModal, NewsCard, and all page components.