### PR TITLE
fix: scroll to hash section after Directus data loads

### DIFF
--- a/src/app/services/aesthetic-solutions/page.tsx
+++ b/src/app/services/aesthetic-solutions/page.tsx
@@ -47,6 +47,7 @@ export default function AestheticSolutionsPage() {
     }, [rawSections, language]);
 
     // Handle hash links with scroll offset for fixed header
+    // depends on `sections` so scroll re-runs after Directus data renders
     useEffect(() => {
         const getHeaderHeight = () => {
             if (window.innerWidth <= 768) return 60;
@@ -75,7 +76,7 @@ export default function AestheticSolutionsPage() {
             clearTimeout(timeoutId);
             window.removeEventListener("hashchange", scrollToHash);
         };
-    }, []);
+    }, [sections]);
 
 
     const t = useTranslation();

--- a/src/app/services/engineering-solutions/page.tsx
+++ b/src/app/services/engineering-solutions/page.tsx
@@ -40,6 +40,7 @@ export default function EngineeringSolutionsPage() {
     }, [rawSections, language]);
 
     // Handle hash links with scroll offset for fixed header
+    // depends on `sections` so scroll re-runs after Directus data renders
     useEffect(() => {
         const getHeaderHeight = () => {
             if (window.innerWidth <= 768) return 60;
@@ -68,7 +69,7 @@ export default function EngineeringSolutionsPage() {
             clearTimeout(timeoutId);
             window.removeEventListener("hashchange", scrollToHash);
         };
-    }, []);
+    }, [sections]);
 
 
 


### PR DESCRIPTION
scrollToHash effect was running at mount (100ms) before sections were fetched from Directus, so getElementById returned null. Adding `sections` as dependency re-runs the effect once data renders.